### PR TITLE
Added SPM support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,61 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AnyCodable",
+        "repositoryURL": "https://github.com/Flight-School/AnyCodable.git",
+        "state": {
+          "branch": null,
+          "revision": "876d162385e9862ae8b3c8d65dc301312b040005",
+          "version": "0.6.0"
+        }
+      },
+      {
+        "package": "Base58Swift",
+        "repositoryURL": "https://github.com/keefertaylor/Base58Swift.git",
+        "state": {
+          "branch": null,
+          "revision": "1c13ea6b07f1584660526f8bde3d4cc150e91acd",
+          "version": "2.1.14"
+        }
+      },
+      {
+        "package": "BigInt",
+        "repositoryURL": "https://github.com/attaswift/BigInt.git",
+        "state": {
+          "branch": null,
+          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+          "version": "5.3.0"
+        }
+      },
+      {
+        "package": "KeychainAccess",
+        "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
+        "state": {
+          "branch": null,
+          "revision": "84e546727d66f1adc5439debad16270d0fdd04e7",
+          "version": "4.2.2"
+        }
+      },
+      {
+        "package": "secp256k1",
+        "repositoryURL": "https://github.com/GigaBitcoin/secp256k1.swift.git",
+        "state": {
+          "branch": null,
+          "revision": "1a796f738bdcd84b41d05f92593188b23163e60b",
+          "version": "0.7.0"
+        }
+      },
+      {
+        "package": "TweetNacl",
+        "repositoryURL": "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git",
+        "state": {
+          "branch": null,
+          "revision": "f8fd111642bf2336b11ef9ea828510693106e954",
+          "version": "1.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+let package = Package(
+    name: "nearclientios",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v12)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "nearclientios",
+            targets: ["nearclientios"]
+        ),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .exact("4.2.2")),
+        .package(url: "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git", .exact("1.1.0")),
+        .package(url: "https://github.com/Flight-School/AnyCodable.git", .exact("0.6.0")),
+        .package(url: "https://github.com/keefertaylor/Base58Swift.git", from: "2.1.0"),
+        .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .exact("0.7.0"))
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "nearclientios",
+            dependencies: [
+                "KeychainAccess",
+                .product(name: "TweetNacl", package: "tweetnacl-swiftwrap"),
+                "AnyCodable",
+                "Base58Swift",
+                .product(name: "secp256k1", package: "secp256k1.swift"),
+            ],
+            path: "./nearclientios/Sources"
+        ),
+    ]
+)

--- a/nearclientios/Sources/Utils/AppInfo.swift
+++ b/nearclientios/Sources/Utils/AppInfo.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 extension UIApplication {
   static var urlSchemes: [String]? {

--- a/nearclientios/Sources/WalletAccount.swift
+++ b/nearclientios/Sources/WalletAccount.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 import KeychainAccess
 
 public let APP_SCHEME = "x-nearclientios"


### PR DESCRIPTION
This PR adds support for Swift Package Manager ([issue](https://github.com/near/near-api-swift/issues/2))
Some UIKit imports are added in files where needed (AppInfo.swift uses UIApplication class and WalletAccount.swift uses UIViewController class)

**IMPORTANT**
Not all dependencies versions from .podspec file are available via SPM, some versions were updated so they could be resolved by SPM.

Notes and comments are welcome!